### PR TITLE
feat: Implement OTP verification logic for 2FA-enabled login

### DIFF
--- a/src/app/core/auth/auth.routes.ts
+++ b/src/app/core/auth/auth.routes.ts
@@ -29,6 +29,13 @@ export const authRoutes: Routes = [
             mod => mod.ResetPasswordComponent
           ),
       },
+      {
+        path: 'otp-confirmation',
+        loadComponent: () =>
+          import('./pages/otp-confirmation/otp-confirmation.component').then(
+            mod => mod.OtpConfirmationComponent
+          ),
+      },
     ],
   },
 ];

--- a/src/app/core/auth/models/request/resend-otp-request.model.ts
+++ b/src/app/core/auth/models/request/resend-otp-request.model.ts
@@ -1,0 +1,10 @@
+export enum ResendOtpPurpose {
+  Login = 0,
+  Enable2FA = 1,
+  Disable2Fa = 2,
+}
+
+export interface ResendOtpRequest {
+  email: string;
+  purpose: ResendOtpPurpose;
+}

--- a/src/app/core/auth/models/request/verify-otp-request.model.ts
+++ b/src/app/core/auth/models/request/verify-otp-request.model.ts
@@ -1,0 +1,4 @@
+export interface VerifyOtpRequest {
+  otpCode: string;
+  email: string;
+}

--- a/src/app/core/auth/pages/otp-confirmation/otp-confirmation.component.css
+++ b/src/app/core/auth/pages/otp-confirmation/otp-confirmation.component.css
@@ -1,0 +1,5 @@
+a.disable {
+  opacity: 0.5;
+  cursor: default;
+  pointer-events: none;
+}

--- a/src/app/core/auth/pages/otp-confirmation/otp-confirmation.component.html
+++ b/src/app/core/auth/pages/otp-confirmation/otp-confirmation.component.html
@@ -1,0 +1,44 @@
+<app-auth-layout>
+  <h1 class="mb-2 text-center text-xl font-bold">Xác minh 2 bước</h1>
+  <p class="mb-6 text-center text-[15px] opacity-80">
+    Một mã xác nhận gồm 6 chữ số đã được gửi tới
+    <br />
+    <strong>{{ email() }}</strong>
+  </p>
+
+  <form (ngSubmit)="onSubmit()" class="flex flex-col gap-4">
+    <div class="flex w-full flex-col items-center gap-5">
+      <p-inputotp
+        name="otpCode"
+        [(ngModel)]="value"
+        [invalid]="isInvalidValue"
+        [length]="6"
+        [integerOnly]="true" />
+
+      <p class="text-center">
+        Không nhận được mã?
+        <a
+          class="cursor-pointer font-medium text-primary underline"
+          [class.disable]="isResendDisabled()"
+          (click)="onResendCode($event)">
+          {{ resendLinkText }}
+        </a>
+      </p>
+    </div>
+
+    <p-button
+      label="Xác nhận"
+      styleClass="mt-2"
+      type="submit"
+      [fluid]="true"
+      [loading]="isLoading()" />
+    <p
+      class="mx-auto mt-1 text-center text-[12px] opacity-80 dark:text-[#64748b]">
+      Việc bạn tiếp tục sử dụng trang web này đồng nghĩa bạn đồng ý với
+      <a href="#!" class="cursor-pointer text-primary underline">
+        điều khoản sử dụng
+      </a>
+      của chúng tôi.
+    </p>
+  </form>
+</app-auth-layout>

--- a/src/app/core/auth/pages/otp-confirmation/otp-confirmation.component.spec.ts
+++ b/src/app/core/auth/pages/otp-confirmation/otp-confirmation.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { OtpConfirmationComponent } from './otp-confirmation.component';
+
+describe('OtpConfirmationComponent', () => {
+  let component: OtpConfirmationComponent;
+  let fixture: ComponentFixture<OtpConfirmationComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [OtpConfirmationComponent]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(OtpConfirmationComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/core/auth/pages/otp-confirmation/otp-confirmation.component.ts
+++ b/src/app/core/auth/pages/otp-confirmation/otp-confirmation.component.ts
@@ -1,0 +1,116 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  DestroyRef,
+  inject,
+  signal,
+} from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { ActivatedRoute } from '@angular/router';
+
+import { InputOtpModule } from 'primeng/inputotp';
+import { ButtonModule } from 'primeng/button';
+
+import { LoadingService } from '../../../../shared/services/core/loading/loading.service';
+import { TwoFactorService } from '../../services/two-factor.service';
+
+import { AuthLayoutComponent } from '../../auth-layout/auth-layout.component';
+
+import { type VerifyOtpRequest } from '../../models/request/verify-otp-request.model';
+import {
+  ResendOtpPurpose,
+  ResendOtpRequest,
+} from '../../models/request/resend-otp-request.model';
+
+@Component({
+  selector: 'app-otp-confirmation',
+  standalone: true,
+  imports: [FormsModule, InputOtpModule, ButtonModule, AuthLayoutComponent],
+  templateUrl: './otp-confirmation.component.html',
+  styleUrl: './otp-confirmation.component.css',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class OtpConfirmationComponent {
+  private readonly destroyRef = inject(DestroyRef);
+  private readonly activatedRoute = inject(ActivatedRoute);
+  private readonly loadingService = inject(LoadingService);
+  private readonly twoFactorService = inject(TwoFactorService);
+
+  isLoading = this.loadingService.isLoading;
+
+  value = signal<string>('');
+  email = signal<string>('');
+  readonly countdown = signal<number>(10);
+  readonly isResendDisabled = signal<boolean>(true);
+
+  private countdownInterval!: ReturnType<typeof setInterval>;
+
+  ngOnInit(): void {
+    const emailParam = this.activatedRoute.snapshot.queryParamMap.get('email');
+    if (emailParam) {
+      this.email.set(emailParam);
+    }
+
+    this.startCountdown();
+
+    this.destroyRef.onDestroy(() => {
+      clearInterval(this.countdownInterval);
+    });
+  }
+
+  get isInvalidValue() {
+    const otpCode = this.value();
+    return !otpCode || otpCode.length !== 6;
+  }
+
+  get resendLinkText() {
+    return this.isResendDisabled()
+      ? `Gửi lại mã (${this.countdown()}s)`
+      : 'Gửi lại mã';
+  }
+
+  onSubmit() {
+    if (this.isInvalidValue) {
+      return;
+    }
+
+    const request: VerifyOtpRequest = {
+      otpCode: this.value(),
+      email: this.email(),
+    };
+    this.twoFactorService.verifyTwoFactor(request).subscribe();
+  }
+
+  onResendCode(event: Event) {
+    event.preventDefault();
+
+    if (this.isResendDisabled()) return;
+
+    const request: ResendOtpRequest = {
+      email: this.email(),
+      purpose: ResendOtpPurpose.Login,
+    };
+    this.twoFactorService
+      .resendOtp(request)
+      .subscribe(() => this.startCountdown());
+  }
+
+  private startCountdown(): void {
+    this.isResendDisabled.set(true);
+    this.countdown.set(120);
+
+    this.countdownInterval = setInterval(() => {
+      const current = this.countdown();
+      if (current <= 1) {
+        this.stopCountdown();
+      } else {
+        this.countdown.set(current - 1);
+      }
+    }, 1000);
+  }
+
+  private stopCountdown(): void {
+    clearInterval(this.countdownInterval);
+    this.isResendDisabled.set(false);
+  }
+}

--- a/src/app/core/auth/services/auth.service.ts
+++ b/src/app/core/auth/services/auth.service.ts
@@ -51,7 +51,6 @@ export class AuthService {
         map(res => {
           if (res.statusCode === StatusCode.SUCCESS && res.data) {
             this.handleLoginSuccess(res.data);
-            this.redirectUserAfterLogin();
             return res.data;
           }
 
@@ -102,14 +101,15 @@ export class AuthService {
     );
   }
 
+  handleLoginSuccess(data: AuthTokenResponse): void {
+    this.handleTokenStorage(data);
+    this.redirectUserAfterLogin();
+    this.isLoggedInSignal.set(true);
+  }
+
   // ---------------------------
   //  Private Helper Functions
   // ---------------------------
-
-  private handleLoginSuccess(data: AuthTokenResponse): void {
-    this.handleTokenStorage(data);
-    this.isLoggedInSignal.set(true);
-  }
 
   private handleTokenStorage(data: AuthTokenResponse): void {
     const { accessToken, refreshToken, expiresIn } = data;
@@ -145,6 +145,12 @@ export class AuthService {
           'Đăng nhập thất bại',
           'Tài khoản của bạn đã bị vô hiệu hóa.'
         );
+        break;
+
+      case StatusCode.REQUIRES_OTP_VERIFICATION:
+        this.router.navigate(['/auth/otp-confirmation'], {
+          queryParams: { email },
+        });
         break;
 
       default:
@@ -186,9 +192,9 @@ export class AuthService {
       };
 
       const firstRole = user.roles[0];
-      const redirectUrl = roleRedirectMap[firstRole] ?? '/';
+      const redirectUrl = roleRedirectMap[firstRole] ?? '/school-admin';
 
-      this.router.navigateByUrl(redirectUrl);
+      this.router.navigateByUrl(redirectUrl, { replaceUrl: true });
     });
   }
 }

--- a/src/app/core/auth/services/two-factor.service.ts
+++ b/src/app/core/auth/services/two-factor.service.ts
@@ -5,6 +5,8 @@ import { Observable, catchError, map, of, tap } from 'rxjs';
 
 import { environment } from '../../../../environments/environment';
 
+import { AuthService } from './auth.service';
+import { UserService } from '../../../shared/services/api/user/user.service';
 import { RequestService } from '../../../shared/services/core/request/request.service';
 import { ToastHandlingService } from '../../../shared/services/core/toast/toast-handling.service';
 
@@ -14,11 +16,16 @@ import {
   type RequestEnableDisable2FA,
   type ConfirmEnableDisable2FA,
 } from '../../../shared/pages/settings-page/account-settings/models/toggle-2fa-request.model';
+import { type VerifyOtpRequest } from '../models/request/verify-otp-request.model';
+import { type AuthTokenResponse } from '../models/response/auth-response.model';
+import { type ResendOtpRequest } from '../models/request/resend-otp-request.model';
 
 @Injectable({
   providedIn: 'root',
 })
 export class TwoFactorService {
+  private readonly authService = inject(AuthService);
+  private readonly userService = inject(UserService);
   private readonly requestService = inject(RequestService);
   private readonly toastHandlingService = inject(ToastHandlingService);
 
@@ -27,6 +34,8 @@ export class TwoFactorService {
   private readonly CONFIRM_ENABLE_TWO_FACTOR_API_URL = `${this.BASE_API_URL}/auth/security/confirm-enable-2fa`;
   private readonly REQUEST_DISABLE_TWO_FACTOR_API_URL = `${this.BASE_API_URL}/auth/security/request-disable-2fa`;
   private readonly CONFIRM_DISABLE_TWO_FACTOR_API_URL = `${this.BASE_API_URL}/auth/security/confirm-disable-2fa`;
+  private readonly VERIFY_OTP_LOGIN_API_URL = `${this.BASE_API_URL}/auth/verify-otp-login`;
+  private readonly RESEND_OTP_LOGIN_API_URL = `${this.BASE_API_URL}/auth/resend-otp`;
 
   requestEnableDisable2FA(
     request: RequestEnableDisable2FA,
@@ -62,6 +71,28 @@ export class TwoFactorService {
       );
   }
 
+  verifyTwoFactor(
+    request: VerifyOtpRequest
+  ): Observable<AuthTokenResponse | null> {
+    return this.requestService
+      .post<AuthTokenResponse>(this.VERIFY_OTP_LOGIN_API_URL, request)
+      .pipe(
+        tap(res => this.handleVerify2FAResponse(res, res.data)),
+        map(res => this.extractAuthDataFromResponse(res)),
+        catchError((err: HttpErrorResponse) => this.handleVerify2FAError(err))
+      );
+  }
+
+  resendOtp(request: ResendOtpRequest): Observable<void> {
+    return this.requestService
+      .post(this.RESEND_OTP_LOGIN_API_URL, request)
+      .pipe(
+        tap(res => this.handleResendOtpResponse(res)),
+        map(() => void 0),
+        catchError((err: HttpErrorResponse) => this.handleResendOtpError(err))
+      );
+  }
+
   // ---------------------------
   //  Private Helper Functions
   // ---------------------------
@@ -71,12 +102,12 @@ export class TwoFactorService {
     if (res.statusCode === StatusCode.SUCCESS) {
       this.toastHandlingService.success(
         'Yêu cầu thành công',
-        `Vui lòng kiểm tra email của bạn để xác nhận việc ${action} xác thực hai bước.`
+        `Vui lòng kiểm tra hộp thư của bạn để xác nhận việc ${action} xác thực hai bước.`
       );
     } else {
       this.toastHandlingService.error(
         'Đã xảy ra lỗi',
-        `Không thể gửi yêu cầu ${action} xác thực hai bước. Vui lòng thử lại.`
+        `Không thể gửi yêu cầu ${action} xác thực hai bước. Vui lòng thử lại sau.`
       );
     }
   }
@@ -100,23 +131,72 @@ export class TwoFactorService {
         'Xác nhận thành công',
         `Xác thực hai bước đã được ${action} thành công cho tài khoản của bạn.`
       );
+      this.userService.updateCurrentUserPartial({ is2FAEnabled: !isEnable });
     } else {
       this.toastHandlingService.error(
         'Thất bại',
-        `Không thể ${action} xác thực hai bước. Vui lòng thử lại.`
+        `Không thể ${action} xác thực hai bước. Vui lòng thử lại sau.`
       );
     }
   }
 
   private handleConfirm2FAError(err: HttpErrorResponse): Observable<void> {
-    if (err.error?.statusCode === StatusCode.OTP_INVALID_OR_EXPIRED) {
-      this.toastHandlingService.error(
-        'Lỗi xác thực',
-        'Mã xác minh không hợp lệ hoặc đã hết hạn. Vui lòng kiểm tra lại mã OTP.'
+    this.handleOtpInvalidError(err);
+    return of(void 0);
+  }
+
+  private handleVerify2FAResponse(res: any, data?: AuthTokenResponse): void {
+    if (res.statusCode === StatusCode.SUCCESS && data) {
+      this.authService.handleLoginSuccess(data);
+    } else {
+      this.toastHandlingService.errorGeneral();
+    }
+  }
+
+  private handleVerify2FAError(err: HttpErrorResponse): Observable<null> {
+    this.handleOtpInvalidError(err);
+    return of(null);
+  }
+
+  private extractAuthDataFromResponse(res: any): AuthTokenResponse | null {
+    if (res.statusCode === StatusCode.SUCCESS && res.data) {
+      return res.data;
+    }
+    return null;
+  }
+
+  private handleResendOtpResponse(res: any): void {
+    if (res.statusCode === StatusCode.SUCCESS) {
+      this.toastHandlingService.success(
+        'Yêu cầu đã được xử lý',
+        'Một mã xác minh gồm 6 chữ số đã được gửi tới địa chỉ email của bạn. Vui lòng kiểm tra hộp thư để tiếp tục.'
       );
     } else {
       this.toastHandlingService.errorGeneral();
     }
+  }
+
+  private handleResendOtpError(err: HttpErrorResponse): Observable<void> {
+    this.handleOtpInvalidError(err);
     return of(void 0);
+  }
+
+  private handleOtpInvalidError(err: HttpErrorResponse): void {
+    switch (err.error?.statusCode) {
+      case StatusCode.OTP_INVALID_OR_EXPIRED:
+        this.toastHandlingService.error(
+          'Lỗi xác thực',
+          'Mã xác minh không hợp lệ hoặc đã hết hạn. Vui lòng kiểm tra lại mã OTP.'
+        );
+        break;
+      case StatusCode.USER_NOT_EXISTS:
+        this.toastHandlingService.error(
+          'Email không tồn tại',
+          'Không tìm thấy tài khoản nào tương ứng với địa chỉ email của bạn.'
+        );
+        break;
+      default:
+        this.toastHandlingService.errorGeneral();
+    }
   }
 }

--- a/src/app/core/interceptors/error.interceptor.ts
+++ b/src/app/core/interceptors/error.interceptor.ts
@@ -20,15 +20,18 @@ export const errorInterceptor: HttpInterceptorFn = (req, next) => {
   const confirmationService = inject(ConfirmationService);
 
   const excludedUrls = ['/auth/login', '/auth/refresh-token'];
-  const shouldSkip401Toast = excludedUrls.some(url => req.url.includes(url));
+  const shouldSkipToast = excludedUrls.some(url => req.url.includes(url));
 
   return next(req).pipe(
     catchError((error: HttpErrorResponse) => {
       if (error.status === 0) {
-        toastHandlingService.error('Lỗi', 'Không thể kết nối đến máy chủ.'); // ? Cái này thì chắc báo toast thôi
+        toastHandlingService.error(
+          'Lỗi hệ thống',
+          'Không thể kết nối đến máy chủ.'
+        );
       } else if (error.status >= 500) {
         toastHandlingService.errorGeneral(); // ? Sau sẽ redirect tới trang 500
-      } else if (error.status === 401 && !shouldSkip401Toast) {
+      } else if (error.status === 401 && !shouldSkipToast) {
         globalModalService.close();
         confirmationService.confirm({
           message: 'Vui lòng đăng nhập lại.',
@@ -46,9 +49,9 @@ export const errorInterceptor: HttpInterceptorFn = (req, next) => {
             });
           },
         });
-      } else if (error.status === 403) {
+      } else if (error.status === 403 && !shouldSkipToast) {
         toastHandlingService.error(
-          'Lỗi',
+          'Không có quyền truy cập',
           'Bạn không có quyền truy cập chức năng này.'
         ); // ? Sau sẽ redirect tới trang 403
       }

--- a/src/app/core/layout/header/user-actions/information/information.component.html
+++ b/src/app/core/layout/header/user-actions/information/information.component.html
@@ -1,5 +1,5 @@
 <div
-  class="absolute right-0 top-[46px] w-[calc(100%-35px)] rounded border border-gray-100 shadow-main dark:border-dark-500"
+  class="absolute right-0 top-[46px] w-[200px] rounded border border-gray-100 shadow-main dark:border-dark-500"
   clickOutsideSubmenu
   (clickOutside)="clickOutside.emit()">
   <div

--- a/src/app/features/teacher/file-manager/lesson-table/lesson-table.component.html
+++ b/src/app/features/teacher/file-manager/lesson-table/lesson-table.component.html
@@ -10,8 +10,7 @@
   [first]="first()"
   [totalRecords]="totalRecords()"
   [loading]="loading()"
-  (onLazyLoad)="loadDataLazy($event)"
-  (onPage)="pageChange($event)"
+  (onLazyLoad)="loadLessonsLazy($event)"
   currentPageReportTemplate="
       Hiển thị {first} đến {last} trên {totalRecords} bài học
     ">

--- a/src/app/features/teacher/file-manager/lesson-table/lesson-table.component.ts
+++ b/src/app/features/teacher/file-manager/lesson-table/lesson-table.component.ts
@@ -45,7 +45,7 @@ export class LessonTableComponent {
     return PAGE_SIZE;
   }
 
-  loadDataLazy(event: TableLazyLoadEvent) {
+  loadLessonsLazy(event: TableLazyLoadEvent) {
     const rows = event.rows ?? this.maxRowsByPage;
     const first = event.first ?? 0;
     const page = first / rows;
@@ -60,27 +60,4 @@ export class LessonTableComponent {
   }
 
   onSearchTriggered(term: string) {}
-
-  next() {
-    this.first.set(this.first() + this.rows());
-  }
-
-  prev() {
-    this.first.set(this.first() - this.rows());
-  }
-
-  pageChange(event: any) {
-    this.first.set(event.first);
-    this.rows.set(event.rows);
-  }
-
-  isLastPage(): boolean {
-    return this.lessons()
-      ? this.first() + this.rows() >= this.lessons().length
-      : true;
-  }
-
-  isFirstPage(): boolean {
-    return this.lessons() ? this.first() === 0 : true;
-  }
 }

--- a/src/app/shared/components/import-accounts/import-account-modals/import-account-modals.component.ts
+++ b/src/app/shared/components/import-accounts/import-account-modals/import-account-modals.component.ts
@@ -16,10 +16,12 @@ import { ImportUserAccountsService } from '../services/import-user-accounts.serv
 import { DownloadTemplateService } from '../services/download-template.service';
 
 import { MODAL_DATA } from '../../../tokens/injection/modal-data.token';
+
 import {
   MAX_IMPORT_FILE_SIZE,
   ALLOWED_IMPORT_EXTENSIONS,
 } from '../../../constants/common.constant';
+import { TemplateType } from '../../../models/enum/template-type.enum';
 
 @Component({
   selector: 'app-import-account-modals',
@@ -126,7 +128,8 @@ export class ImportAccountModalsComponent {
   }
 
   downloadTemplate() {
-    this.downloadTemplateService.downloadTemplate().subscribe();
+    const type = TemplateType.ImportAccountsTemplate;
+    this.downloadTemplateService.downloadTemplate(type).subscribe();
   }
 
   private async handleFile(file: File) {

--- a/src/app/shared/components/import-accounts/services/download-template.service.ts
+++ b/src/app/shared/components/import-accounts/services/download-template.service.ts
@@ -13,6 +13,8 @@ import {
   triggerBlobDownload,
 } from '../../../utils/util-functions';
 
+import { type TemplateType } from '../../../models/enum/template-type.enum';
+
 @Injectable({
   providedIn: 'root',
 })
@@ -23,9 +25,9 @@ export class DownloadTemplateService {
   private readonly BASE_API_URL = environment.baseApiUrl;
   private readonly DOWNLOAD_TEMPLATE_API_URL = `${this.BASE_API_URL}/users/import-template`;
 
-  downloadTemplate(): Observable<HttpResponse<Blob>> {
+  downloadTemplate(type: TemplateType): Observable<HttpResponse<Blob>> {
     return this.requestService
-      .getFile(this.DOWNLOAD_TEMPLATE_API_URL, undefined, {
+      .getFile(`${this.DOWNLOAD_TEMPLATE_API_URL}/${type}`, undefined, {
         loadingKey: 'download-template',
       })
       .pipe(

--- a/src/app/shared/models/enum/template-type.enum.ts
+++ b/src/app/shared/models/enum/template-type.enum.ts
@@ -1,0 +1,3 @@
+export enum TemplateType {
+  ImportAccountsTemplate = 0,
+}

--- a/src/app/shared/pages/settings-page/account-settings/otp-modal/otp-modal.component.html
+++ b/src/app/shared/pages/settings-page/account-settings/otp-modal/otp-modal.component.html
@@ -41,6 +41,7 @@
             : 'Gửi lại mã'
         "
         variant="outlined"
+        type="button"
         size="small"
         (onClick)="onResendCode()"
         [disabled]="isResendDisabled()" />

--- a/src/app/shared/pages/settings-page/account-settings/password-modal/password-modal.component.html
+++ b/src/app/shared/pages/settings-page/account-settings/password-modal/password-modal.component.html
@@ -30,24 +30,49 @@
               : ''
           ">
           <input
-            type="password"
-            name="currentPassword"
             id="currentPassword"
-            placeholder="Nhập mật khẩu hiện tại của bạn"
             formControlName="currentPassword"
-            (blur)="onBlur('currentPassword')"
+            name="currentPassword"
+            placeholder="Nhập mật khẩu hiện tại của bạn"
             class="h-full w-full border-none bg-transparent outline-none placeholder:font-medium placeholder:tracking-wide placeholder:text-gray-500 dark:text-white dark:placeholder:text-gray-400"
             [class.text-[#f33a58]]="
               currentPassword.invalid &&
               currentPassword.touched &&
               currentPassword.dirty
-            " />
+            "
+            [type]="isShowPassword() ? 'text' : 'password'"
+            (blur)="onBlur('currentPassword')" />
           @if (currentPassword.invalid && currentPassword.touched) {
             <div class="absolute right-[14px] top-1/2 -translate-y-1/2">
               <i
                 class="fa-solid fa-triangle-exclamation animate-shake text-base text-[#f33a58]">
               </i>
             </div>
+          }
+          @if (isShowPassword()) {
+            <span
+              tabindex="-1"
+              class="material-symbols-outlined absolute right-[14px] top-[17%] block cursor-pointer text-lg text-[#64748b]"
+              (mousedown)="$event.preventDefault()"
+              (click)="
+                toggleShowPassword();
+                $event.stopPropagation();
+                $event.preventDefault()
+              ">
+              visibility
+            </span>
+          } @else {
+            <span
+              tabindex="-1"
+              class="material-symbols-outlined absolute right-[14px] top-[17%] block cursor-pointer text-lg text-[#64748b]"
+              (mousedown)="$event.preventDefault()"
+              (click)="
+                toggleShowPassword();
+                $event.stopPropagation();
+                $event.preventDefault()
+              ">
+              visibility_off
+            </span>
           }
         </div>
         @if (currentPassword.invalid && currentPassword.touched) {

--- a/src/app/shared/pages/settings-page/account-settings/password-modal/password-modal.component.ts
+++ b/src/app/shared/pages/settings-page/account-settings/password-modal/password-modal.component.ts
@@ -1,4 +1,9 @@
-import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  inject,
+  signal,
+} from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { RouterLink } from '@angular/router';
 import {
@@ -38,6 +43,8 @@ export class PasswordModalComponent {
 
   isLoading = this.loadingService.is('password-modal');
 
+  isShowPassword = signal<boolean>(false);
+
   constructor() {
     this.form = this.fb.group({
       currentPassword: ['', Validators.required],
@@ -69,6 +76,10 @@ export class PasswordModalComponent {
         next: () => this.openOtpModal(),
         error: () => this.form.reset,
       });
+  }
+
+  toggleShowPassword(): void {
+    this.isShowPassword.set(!this.isShowPassword());
   }
 
   getErrorMessage(controlName: string): string {

--- a/src/app/shared/services/api/user/user.service.ts
+++ b/src/app/shared/services/api/user/user.service.ts
@@ -40,10 +40,6 @@ export class UserService {
     );
   }
 
-  clearCurrentUser(): void {
-    this.setCurrentUser(null);
-  }
-
   updateUserProfile(request: UpdateProfileRequest): Observable<User | null> {
     return this.requestService
       .put<User>(this.USER_PROFILE_API_URL, request)
@@ -52,6 +48,17 @@ export class UserService {
         map(res => this.extractUserFromResponse(res)),
         catchError(() => this.handleErrorResponse())
       );
+  }
+
+  updateCurrentUserPartial(update: Partial<User>): void {
+    const current = this.currentUserSignal();
+    if (!current) return;
+    const merged = { ...current, ...update };
+    this.setCurrentUser(merged);
+  }
+
+  clearCurrentUser(): void {
+    this.setCurrentUser(null);
   }
 
   // ---------------------------


### PR DESCRIPTION
- Before: Login process did not support OTP verification when two-factor authentication was enabled -> Toast 403 error.
- After: Added functionality to verify OTP during login if the user has 2FA enabled.