### PR TITLE
fix: Fix bug can not refresh token. Fix bug can not resend confirm email.

### DIFF
--- a/src/app/core/auth/services/email-verification.service.ts
+++ b/src/app/core/auth/services/email-verification.service.ts
@@ -21,7 +21,7 @@ export class EmailVerificationService {
 
   private readonly BASE_API_URL = environment.baseApiUrl;
   private readonly CONFIRM_EMAIL_API_URL = `${this.BASE_API_URL}/auth/confirm-email`;
-  private readonly RESEND_CONFIRM_EMAIL_API_URL = `${this.BASE_API_URL}/auth/resend-confirm-email`;
+  private readonly RESEND_CONFIRM_EMAIL_API_URL = `${this.BASE_API_URL}/auth/resend-confirmation-email`;
 
   private readonly CLIENT_URL = `${environment.clientUrl}/auth/login`;
 

--- a/src/app/core/layout/navbar/navbar.component.ts
+++ b/src/app/core/layout/navbar/navbar.component.ts
@@ -118,14 +118,6 @@ export class NavbarComponent implements OnInit {
     const schoolAdminNav: NavItem[] = isSchoolAdmin
       ? [
           {
-            label: 'Trường học',
-            icon: 'school',
-            link: '/school-admin/schools',
-            type: 'link',
-            isActive: false,
-            submenuItems: [],
-          },
-          {
             label: 'Giáo viên',
             icon: 'co_present',
             link: '/school-admin/teachers',

--- a/src/app/shared/components/lesson-details/preview-lesson/preview-lesson.component.ts
+++ b/src/app/shared/components/lesson-details/preview-lesson/preview-lesson.component.ts
@@ -79,7 +79,7 @@ export class PreviewLessonComponent implements OnInit {
     });
 
     this.lessonMaterialService
-      .fetchLessonMaterialById(this.materialId())
+      .getLessonMaterialById(this.materialId())
       .subscribe();
   }
 

--- a/src/app/shared/directives/route-metadata/route-metadata.directive.ts
+++ b/src/app/shared/directives/route-metadata/route-metadata.directive.ts
@@ -67,7 +67,7 @@ export class RouteMetadataDirective implements OnInit {
 
     this.breadcrumbService.setBreadcrumbs([
       {
-        label: 'Bảng Thống kê',
+        label: 'Bảng thống kê',
         icon: 'pi pi-home',
         routerLink: '/',
       },

--- a/src/app/shared/pages/settings-page/personal-information/update-avatar-modal/update-avatar-modal.component.ts
+++ b/src/app/shared/pages/settings-page/personal-information/update-avatar-modal/update-avatar-modal.component.ts
@@ -1,8 +1,10 @@
 import {
   ChangeDetectionStrategy,
   Component,
+  ElementRef,
   inject,
   signal,
+  viewChild,
 } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
@@ -44,6 +46,8 @@ interface AvatarModalData {
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class UpdateAvatarModalComponent {
+  private readonly avatarInputRef = viewChild<ElementRef>('avatarInput');
+
   private readonly uploadFileService = inject(UploadFileService);
   private readonly toastHandlingService = inject(ToastHandlingService);
   private readonly globalModalService = inject(GlobalModalService);
@@ -166,6 +170,11 @@ export class UpdateAvatarModalComponent {
       translateV: 0,
     });
     this.imageChangedEvent.set(null);
+
+    const input = this.avatarInputRef()?.nativeElement as HTMLInputElement;
+    if (input) {
+      input.value = '';
+    }
   }
 
   triggerClickInput(input: HTMLInputElement) {

--- a/src/app/shared/services/api/lesson-materials/lesson-materials.service.ts
+++ b/src/app/shared/services/api/lesson-materials/lesson-materials.service.ts
@@ -58,7 +58,7 @@ export class LessonMaterialsService {
       );
   }
 
-  fetchLessonMaterialById(id: string): Observable<LessonMaterial | null> {
+  getLessonMaterialById(id: string): Observable<LessonMaterial | null> {
     return this.requestService
       .get<LessonMaterial>(`${this.LESSON_MATERIALS_API_URL}/${id}`)
       .pipe(


### PR DESCRIPTION
- Before: Refresh token API sometimes return 401 with error message: Invalid token or expired. Wrong API end-point for resend-confirm-email so that can not resend confirmation email with new account
- After: Refresh token just refresh 1 times if have many request proceed parallel then must wait the refresh thread to complete. Refactor API end-point from resend-confirm-email to resend-confirmation-email