### PR TITLE
feat: Add state cleanup when GenerateLessonMain component is destroyed for next generate session

### DIFF
--- a/src/app/features/teacher/generate-lesson/generate-lesson-completed/generate-lesson-card/generate-lesson-card.component.html
+++ b/src/app/features/teacher/generate-lesson/generate-lesson-completed/generate-lesson-card/generate-lesson-card.component.html
@@ -9,7 +9,7 @@
     {{ job().topic }}
   </h3>
   <span class="mt-auto text-xs text-gray-400 dark:text-gray-300">
-    {{ job().createdAt | date: 'longDate' }} ·
+    {{ job().createdAt | date: 'HH:mm:ss, EEEE, dd MMMM, yyyy' }} ·
     {{ job().sourceBlobNames.length }} tài liệu
   </span>
 </a>

--- a/src/app/features/teacher/generate-lesson/generate-lesson-main/generate-lesson-main.component.ts
+++ b/src/app/features/teacher/generate-lesson/generate-lesson-main/generate-lesson-main.component.ts
@@ -14,6 +14,7 @@ import { ProgressSpinnerModule } from 'primeng/progressspinner';
 import { AiJobsService } from './services/api/ai-jobs.service';
 import { AiSocketService } from './services/api/ai-socket.service';
 import { LoadingService } from '../../../../shared/services/core/loading/loading.service';
+import { ResourcesStateService } from './services/utils/resources-state.service';
 
 import { GenerateLessonUploadComponent } from './generate-lesson-upload/generate-lesson-upload.component';
 import { GenerateLessonChatComponent } from './generate-lesson-chat/generate-lesson-chat.component';
@@ -39,6 +40,7 @@ export class GenerateLessonMainComponent implements OnInit, OnChanges {
   private readonly aiJobService = inject(AiJobsService);
   private readonly aiSocketService = inject(AiSocketService);
   private readonly loadingService = inject(LoadingService);
+  private readonly resourceStateService = inject(ResourcesStateService);
 
   jobId = input<string>();
 
@@ -46,7 +48,10 @@ export class GenerateLessonMainComponent implements OnInit, OnChanges {
   job = this.aiJobService.job;
 
   constructor() {
-    this.destroyRef.onDestroy(() => this.aiSocketService.disconnect());
+    this.destroyRef.onDestroy(() => {
+      this.aiSocketService.disconnect();
+      this.resourceStateService.resetAll();
+    });
   }
 
   ngOnInit(): void {
@@ -61,6 +66,7 @@ export class GenerateLessonMainComponent implements OnInit, OnChanges {
     if (changes['jobId']) {
       const newJobId = this.jobId();
       if (newJobId) {
+        this.resourceStateService.resetAll();
         this.aiJobService.getJobById(newJobId).subscribe();
       } else {
         this.aiJobService.clearJob();

--- a/src/app/features/teacher/generate-lesson/generate-lesson-main/generate-lesson-preview/audio-preview/audio-preview-player/audio-preview-player.component.html
+++ b/src/app/features/teacher/generate-lesson/generate-lesson-main/generate-lesson-preview/audio-preview/audio-preview-player/audio-preview-player.component.html
@@ -51,6 +51,13 @@
       @if (!hasGeneratedSuccessfully()) {
         <button
           class="flex h-10 items-center gap-2 rounded-bl rounded-br px-4 text-primary transition-colors ease-in hover:bg-[#dee8f6] dark:hover:bg-dark-300"
+          tooltipPosition="bottom"
+          [pTooltip]="
+            !this.folderId() ? 'Vui lòng chọn thư mục trước khi lưu' : ''
+          "
+          [ngClass]="{
+            'pointer-events-none cursor-default opacity-80': !this.folderId(),
+          }"
           (click)="onSaveGeneratedContent()">
           <span class="pi pi-save"></span>
           <span>Lưu nội dung</span>

--- a/src/app/features/teacher/generate-lesson/generate-lesson-main/generate-lesson-preview/audio-preview/audio-preview-player/audio-preview-player.component.ts
+++ b/src/app/features/teacher/generate-lesson/generate-lesson-main/generate-lesson-preview/audio-preview/audio-preview-player/audio-preview-player.component.ts
@@ -8,6 +8,7 @@ import {
   input,
   signal,
 } from '@angular/core';
+import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 
 import { ButtonModule } from 'primeng/button';
@@ -29,6 +30,7 @@ import {
   selector: 'audio-preview-player',
   standalone: true,
   imports: [
+    CommonModule,
     FormsModule,
     SubmenuDirective,
     ButtonModule,

--- a/src/app/features/teacher/generate-lesson/generate-lesson-main/generate-lesson-preview/audio-preview/audio-preview.component.ts
+++ b/src/app/features/teacher/generate-lesson/generate-lesson-main/generate-lesson-preview/audio-preview/audio-preview.component.ts
@@ -271,6 +271,7 @@ export class AudioPreviewComponent implements OnInit {
       acceptButtonProps: {
         label: 'Lưu và tiếp tục',
         size: 'small',
+        disabled: !this.folderId(),
       },
       accept: onAccept,
       reject: onReject,

--- a/src/app/features/teacher/generate-lesson/generate-lesson-main/generate-lesson-preview/video-preview/video-preview-player/video-preview-player.component.html
+++ b/src/app/features/teacher/generate-lesson/generate-lesson-main/generate-lesson-preview/video-preview/video-preview-player/video-preview-player.component.html
@@ -122,8 +122,11 @@
       label="Lưu nội dung"
       size="small"
       icon="pi pi-save"
+      tooltipPosition="bottom"
       [rounded]="true"
       [fluid]="true"
+      [pTooltip]="!this.folderId() ? 'Vui lòng chọn thư mục trước khi lưu' : ''"
+      [disabled]="!this.folderId()"
       (onClick)="onSaveGeneratedContent()" />
   }
   <p-button

--- a/src/app/features/teacher/generate-lesson/generate-lesson-main/generate-lesson-preview/video-preview/video-preview-player/video-preview-player.component.ts
+++ b/src/app/features/teacher/generate-lesson/generate-lesson-main/generate-lesson-preview/video-preview/video-preview-player/video-preview-player.component.ts
@@ -16,6 +16,7 @@ import { VgOverlayPlayModule } from '@videogular/ngx-videogular/overlay-play';
 import { VgBufferingModule } from '@videogular/ngx-videogular/buffering';
 
 import { ButtonModule } from 'primeng/button';
+import { TooltipModule } from 'primeng/tooltip';
 
 import { ResourcesStateService } from '../../../services/utils/resources-state.service';
 import { GenerateSettingsSelectionService } from '../../services/generate-settings-selection.service';
@@ -39,6 +40,7 @@ import {
     VgOverlayPlayModule,
     VgBufferingModule,
     ButtonModule,
+    TooltipModule,
     VideoSettingsMenuComponent,
   ],
   templateUrl: './video-preview-player.component.html',

--- a/src/app/features/teacher/generate-lesson/generate-lesson-main/generate-lesson-preview/video-preview/video-preview.component.ts
+++ b/src/app/features/teacher/generate-lesson/generate-lesson-main/generate-lesson-preview/video-preview/video-preview.component.ts
@@ -262,8 +262,14 @@ export class VideoPreviewComponent implements OnInit {
         Nếu tiếp tục tạo mới dưới định dạng <strong>Video</strong>, nội dung hiện tại sẽ <span class="text-[#f87171] font-medium">bị thay thế</span>.
         <br/><br/>
         Vui lòng lưu lại nếu bạn muốn giữ nội dung đã tạo.
+        ${
+          !this.folderId()
+            ? '<br/><br/><span class="text-xs text-[#f87171]">* Bạn cần chọn thư mục trước khi có thể lưu nội dung</span>'
+            : ''
+        }
       `,
-      closable: false,
+      closable: true,
+      closeOnEscape: true,
       rejectButtonProps: {
         label: 'Tiếp tục không lưu',
         severity: 'secondary',
@@ -273,6 +279,7 @@ export class VideoPreviewComponent implements OnInit {
       acceptButtonProps: {
         label: 'Lưu và tiếp tục',
         size: 'small',
+        disabled: !this.folderId(),
       },
       accept: onAccept,
       reject: onReject,

--- a/src/app/features/teacher/generate-lesson/generate-lesson-main/services/utils/resources-state.service.ts
+++ b/src/app/features/teacher/generate-lesson/generate-lesson-main/services/utils/resources-state.service.ts
@@ -105,4 +105,14 @@ export class ResourcesStateService {
   clearAiGeneratedMetadata() {
     this.aiGeneratedMetadataSignal.set(null);
   }
+
+  resetAll(): void {
+    this.sourceListSignal.set([]);
+    this.isLoadingSignal.set(false);
+    this.hasInteractedSignal.set(false);
+    this.hasPreviewContentSignal.set(false);
+    this.hasGeneratedSuccessfullySignal.set(false);
+    this.generatedTypeSignal.set(null);
+    this.aiGeneratedMetadataSignal.set(null);
+  }
 }

--- a/src/app/shared/components/lesson-details/video-viewer/video-viewer.component.html
+++ b/src/app/shared/components/lesson-details/video-viewer/video-viewer.component.html
@@ -1,7 +1,7 @@
 <div class="absolute inset-0 flex w-full items-center justify-center bg-black">
   <div
     id="video-wrapper"
-    class="video-player relative box-border block h-full w-[95%] overflow-hidden text-sm text-white"
+    class="video-player relative box-border block h-full w-full overflow-hidden text-sm text-white"
     [class.paused]="isPaused()">
     <vg-player
       (onPlayerReady)="onPlayerReady($event)"


### PR DESCRIPTION
- Before:
  - State from previous generation sessions (e.g., uploaded files, preview results) was retained when returning to the generate page.
  - This caused confusion and unintended behavior when starting a new generation.
- After:
  - State is properly cleared when leaving the generate screen.
  - Each generation session now starts fresh with no residual data from the previous one.